### PR TITLE
Removido referencia ao viewControllerToPresent

### DIFF
--- a/Malert/Classes/Util/Malert.swift
+++ b/Malert/Classes/Util/Malert.swift
@@ -186,6 +186,8 @@ extension Malert {
                     if let dismissOnTap = strongSelf.dismissOnTap {
                         dismissOnTap()
                     }
+                    
+                    strongSelf.viewControllerToPresent = nil
                 }
             }
         }


### PR DESCRIPTION
No dismiss, removendo referencia viewControllerToPresent quando o último alerta é removido