### PR TITLE
Added overlay color config, renamed 'round' method, fixed deprecated protocol inheritance

### DIFF
--- a/Malert/Classes/Malert/Malert.swift
+++ b/Malert/Classes/Malert/Malert.swift
@@ -191,4 +191,10 @@ extension Malert {
     public func onDismissMalert(_ block: @escaping (() -> Void)) {
         self.completionBlock = block
     }
+	
+	/* Overlay */
+	public var overlayColor: UIColor? {
+		get { return visibleView.backgroundColor }
+		set { visibleView.backgroundColor = newValue }
+	}
 }

--- a/Malert/Classes/MalertButtonView/MalertButtonView.swift
+++ b/Malert/Classes/MalertButtonView/MalertButtonView.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-protocol MalertActionCallbackProtocol: class {
+protocol MalertActionCallbackProtocol: AnyObject {
     func didTapOnAction()
 }
 

--- a/Malert/Classes/Util/Extensions.swift
+++ b/Malert/Classes/Util/Extensions.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIView {
    
-   public func round(corners: UIRectCorner, radius: CGFloat) {
+   public func roundCorners(corners: UIRectCorner, radius: CGFloat) {
       let path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
       let mask = CAShapeLayer()
       mask.path = path.cgPath


### PR DESCRIPTION
## Added overlay color configuration
You can now set the color of overlay on Malert object through _overlayColor_ property. Color is then set on background color of _visibleView_.
This can be useful for some use cases like when it's required by the design.

## Renamed _round_ method of UIView extension to _roundView_
I've renamed 'round' method of UIView extension since it hides Swift default 'round' method and creates issues when working with classes extending UIView. 
Although I couldn't find where this method is used. Kindly check if I'm missing something.

## MalertActionCallbackProtocol now extends AnyObject
According to Apple deprecation and requirement.

